### PR TITLE
check existence of the user

### DIFF
--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,47 +1,14 @@
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HttpClient, HttpClientModule, HttpErrorResponse, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClient, HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { AngularFireModule } from '@angular/fire';
+import { AngularFireAuth } from '@angular/fire/auth';
 
 import { AppRoutingModule } from './app-routing.module';
 import { AppComponent } from './app.component';
 import { environment } from '../environments/environment';
 import { BearerTokenInterceptor } from './core/interceptors/bearer-token.interceptor';
-
-import { of } from 'rxjs';
-import { catchError, first, mergeMap } from 'rxjs/operators';
-import { AngularFireAuth } from '@angular/fire/auth';
-function initializeApp(http: HttpClient, afAuth: AngularFireAuth) {
-  return () => {
-    return afAuth.idToken.pipe(
-      first(),
-      mergeMap(idToken => {
-        if (!idToken) {
-          return of();
-        }
-
-        // NOTE: dbにUserが存在するか確認している。
-        //       firebaseではログインしていて、自前のapiにはUserが存在していない不整合な状態の時はfirebaseでログアウトする。
-        //       次にfirebaseでログインした時にUserが作られるので不整合は解消される。
-        const url = `${environment.apiHost}/auth/me`;
-        return http.get(url, { responseType: 'text' }).pipe(
-          mergeMap(_response => {
-            // NOTE: Userは存在しているので問題なし
-            return of();
-          }),
-          catchError((response: HttpErrorResponse) => {
-            console.log(response);
-            if (response.status === 404) {
-              // NOTE: 不整合な状態なのでログアウトする
-              afAuth.signOut();
-            }
-            return of();
-          })
-        );
-      })
-    );
-  };
-}
+import { checkExistenceUser } from './core/initializers/check-existence-user';
 
 @NgModule({
   declarations: [AppComponent],
@@ -49,7 +16,7 @@ function initializeApp(http: HttpClient, afAuth: AngularFireAuth) {
   providers: [
     {
       provide: APP_INITIALIZER,
-      useFactory: initializeApp,
+      useFactory: checkExistenceUser,
       deps: [HttpClient, AngularFireAuth],
       multi: true,
     },

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,6 +1,6 @@
 import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
-import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
+import { HttpClient, HttpClientModule, HttpErrorResponse, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { AngularFireModule } from '@angular/fire';
 
 import { AppRoutingModule } from './app-routing.module';
@@ -9,8 +9,38 @@ import { environment } from '../environments/environment';
 import { BearerTokenInterceptor } from './core/interceptors/bearer-token.interceptor';
 
 import { of } from 'rxjs';
-function initializeApp() {
-  return () => of(null);
+import { catchError, first, mergeMap } from 'rxjs/operators';
+import { AngularFireAuth } from '@angular/fire/auth';
+function initializeApp(http: HttpClient, afAuth: AngularFireAuth) {
+  return () => {
+    return afAuth.idToken.pipe(
+      first(),
+      mergeMap(idToken => {
+        if (!idToken) {
+          return of();
+        }
+
+        // NOTE: dbにUserが存在するか確認している。
+        //       firebaseではログインしていて、自前のapiにはUserが存在していない不整合な状態の時はfirebaseでログアウトする。
+        //       次にfirebaseでログインした時にUserが作られるので不整合は解消される。
+        const url = `${environment.apiHost}/auth/me`;
+        return http.get(url, { responseType: 'text' }).pipe(
+          mergeMap(_response => {
+            // NOTE: Userは存在しているので問題なし
+            return of();
+          }),
+          catchError((response: HttpErrorResponse) => {
+            console.log(response);
+            if (response.status === 404) {
+              // NOTE: 不整合な状態なのでログアウトする
+              afAuth.signOut();
+            }
+            return of();
+          })
+        );
+      })
+    );
+  };
 }
 
 @NgModule({
@@ -20,6 +50,7 @@ function initializeApp() {
     {
       provide: APP_INITIALIZER,
       useFactory: initializeApp,
+      deps: [HttpClient, AngularFireAuth],
       multi: true,
     },
     {

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,4 +1,4 @@
-import { NgModule } from '@angular/core';
+import { APP_INITIALIZER, NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { HttpClientModule, HTTP_INTERCEPTORS } from '@angular/common/http';
 import { AngularFireModule } from '@angular/fire';
@@ -8,10 +8,26 @@ import { AppComponent } from './app.component';
 import { environment } from '../environments/environment';
 import { BearerTokenInterceptor } from './core/interceptors/bearer-token.interceptor';
 
+import { of } from 'rxjs';
+function initializeApp() {
+  return () => of(null);
+}
+
 @NgModule({
   declarations: [AppComponent],
   imports: [BrowserModule, AppRoutingModule, HttpClientModule, AngularFireModule.initializeApp(environment.firebase)],
-  providers: [{ provide: HTTP_INTERCEPTORS, useClass: BearerTokenInterceptor, multi: true }],
+  providers: [
+    {
+      provide: APP_INITIALIZER,
+      useFactory: initializeApp,
+      multi: true,
+    },
+    {
+      provide: HTTP_INTERCEPTORS,
+      useClass: BearerTokenInterceptor,
+      multi: true,
+    },
+  ],
   bootstrap: [AppComponent],
 })
 export class AppModule {}

--- a/src/app/core/initializers/check-existence-user.ts
+++ b/src/app/core/initializers/check-existence-user.ts
@@ -1,0 +1,37 @@
+import { HttpClient, HttpErrorResponse } from '@angular/common/http';
+import { of } from 'rxjs';
+import { catchError, first, mergeMap } from 'rxjs/operators';
+import { AngularFireAuth } from '@angular/fire/auth';
+import { environment } from '../../../environments/environment';
+
+export function checkExistenceUser(http: HttpClient, afAuth: AngularFireAuth) {
+  return () => {
+    return afAuth.idToken.pipe(
+      first(),
+      mergeMap(idToken => {
+        if (!idToken) {
+          return of();
+        }
+
+        // NOTE: dbにUserが存在するか確認している。
+        //       firebaseではログインしていて、自前のapiにはUserが存在していない不整合な状態の時はfirebaseでログアウトする。
+        //       次にfirebaseでログインした時にUserが作られるので不整合は解消される。
+        const url = `${environment.apiHost}/auth/me`;
+        return http.get(url, { responseType: 'text' }).pipe(
+          mergeMap(_response => {
+            // NOTE: Userは存在しているので問題なし
+            return of();
+          }),
+          catchError((response: HttpErrorResponse) => {
+            console.log(response);
+            if (response.status === 404) {
+              // NOTE: 不整合な状態なのでログアウトする
+              afAuth.signOut();
+            }
+            return of();
+          })
+        );
+      })
+    );
+  };
+}

--- a/src/app/core/initializers/check-existence-user.ts
+++ b/src/app/core/initializers/check-existence-user.ts
@@ -23,7 +23,6 @@ export function checkExistenceUser(http: HttpClient, afAuth: AngularFireAuth) {
             return of();
           }),
           catchError((response: HttpErrorResponse) => {
-            console.log(response);
             if (response.status === 404) {
               // NOTE: 不整合な状態なのでログアウトする
               afAuth.signOut();

--- a/src/app/core/initializers/check-existence-user.ts
+++ b/src/app/core/initializers/check-existence-user.ts
@@ -1,10 +1,10 @@
 import { HttpClient, HttpErrorResponse } from '@angular/common/http';
-import { of } from 'rxjs';
+import { Observable, of } from 'rxjs';
 import { catchError, first, mergeMap } from 'rxjs/operators';
 import { AngularFireAuth } from '@angular/fire/auth';
 import { environment } from '../../../environments/environment';
 
-export function checkExistenceUser(http: HttpClient, afAuth: AngularFireAuth) {
+export function checkExistenceUser(http: HttpClient, afAuth: AngularFireAuth): () => Observable<unknown> {
   return () => {
     return afAuth.idToken.pipe(
       first(),


### PR DESCRIPTION
手元のDBをリセットしたらFirebaseではログインしているけれどUserが存在しない状態になった。
この場合、AuthGuardはログイン状態とみなすので `/tasks` などにアクセスすることができてしまう。
発生確率は低そうだが一度発生するとサインアウトするまで勝手に解消されないのでweb appの初期化時にチェックするようにした。
- Firebaseでログインしていない => 何も気にしないでOK
- Firebaseでログインしており、/auth/meでデータが取得できる => 対応するUserが存在しているのでOK
- Firebaseでログインしており、/auth/meで404が返ってくる => サインアウトする