### PR TITLE
:sparkles: reauthenticate before delete their account

### DIFF
--- a/src/app/core/services/user-auth.service.ts
+++ b/src/app/core/services/user-auth.service.ts
@@ -47,6 +47,26 @@ export class UserAuthService {
     if (!currentUser) {
       throw "couldn't get firebase user";
     }
+    if (!Array.isArray(currentUser.providerData)) {
+      throw 'no providerData';
+    }
+
+    const providerIds = currentUser.providerData.map(data => data?.providerId);
+    const providerId = providerIds[0];
+    if (!providerId) {
+      throw 'no providerId';
+    }
+
+    switch (providerId) {
+      case 'google.com':
+        await currentUser.reauthenticateWithPopup(new firebase.auth.GoogleAuthProvider());
+        break;
+      case 'twitter.com':
+        await currentUser.reauthenticateWithPopup(new firebase.auth.TwitterAuthProvider());
+        break;
+      default:
+        throw 'no supported provider';
+    }
 
     const url = `${environment.apiHost}/auth/me`;
     await this.http.delete(url).pipe(timeout(TIMEOUT_MSEC)).toPromise();


### PR DESCRIPTION
fix https://github.com/muk-ai/ng-hoge-app/issues/26

> CREDENTIAL_TOO_OLD_LOGIN_AGAIN：ユーザーの資格情報は無効になりました。ユーザーは再度サインインする必要があります。

https://firebase.google.com/docs/reference/rest/auth
有効なjwtの発行などはサインインしなくてもできる。
サインインから時間が経っている（ドキュメントが見つけられなかったが、1hourとかそういう単位だと思われる）と、特定の操作が行えなくなるようだった。そして「アカウントの削除」はその特定の操作の一つのようだ。